### PR TITLE
Fix compatibility issues with decompress 1.4.2 as well as minor issues in models

### DIFF
--- a/disml.opam
+++ b/disml.opam
@@ -25,7 +25,7 @@ depends: [
   "async_ssl" {>= "v0.11.0"}
   "cohttp-async" {>= "1.2.0"}
   "core" {>= "v0.11.3"}
-  "decompress" {>= "0.8"}
+  "decompress" {>= "1.4.2"}
   "odoc" {with-doc & >= "1.3.0"}
   "ppx_deriving_yojson" {>= "3.3"}
   "ppx_sexp_conv" {>= "v0.11.2"}

--- a/lib/dune
+++ b/lib/dune
@@ -22,7 +22,7 @@
 		event_models
 		cache client client_options disml dispatch endpoints event http opcode rl sharder
 	)
-	(libraries checkseum.ocaml core async_ssl cohttp-async decompress logs yojson websocket-async ppx_deriving_yojson.runtime bitmasks)
+	(libraries checkseum.ocaml core async_ssl cohttp-async decompress.zl logs yojson websocket-async ppx_deriving_yojson.runtime bitmasks)
 	(preprocess (pps ppx_sexp_conv ppx_deriving_yojson)))
 
 (include_subdirs unqualified)

--- a/lib/models/event_models.ml
+++ b/lib/models/event_models.ml
@@ -319,7 +319,8 @@ module GuildMemberRemove = struct
         if Cache.GuildMap.mem cache.guilds t.guild_id then
             let guilds = match Cache.GuildMap.find cache.guilds t.guild_id with
             | Some g ->
-                let members = List.filter g.members ~f:(fun m -> m.user.id <> t.user.id) in
+                let members = List.filter g.members ~f:(fun m ->
+                    (User_id_t.get_id m.user.id) <> (User_id.get_id t.user.id)) in
                 let data = { g with members } in
                 Cache.GuildMap.set cache.guilds ~key:t.guild_id ~data
             | None -> cache.guilds in
@@ -342,7 +343,7 @@ module GuildMemberUpdate = struct
             let guilds = match Cache.GuildMap.find cache.guilds t.guild_id with
             | Some g ->
                 let members = List.map g.members ~f:(fun m ->
-                    if m.user.id = t.user.id then
+                    if ((User_id_t.get_id m.user.id) = (User_id.get_id t.user.id)) then
                         { m with nick = t.nick; roles = t.roles }
                     else m) in
                 let data = { g with members } in
@@ -367,7 +368,7 @@ module GuildMembersChunk = struct
             let `Guild_id guild_id = t.guild_id in
             let users = List.map t.members ~f:(fun m -> m.user.id, m.user) in
             let members = List.filter_map t.members ~f:(fun m ->
-                if List.exists g.members ~f:(fun m' -> m'.user.id <> m.user.id) then
+                if List.exists g.members ~f:(fun m' -> (User_id.get_id m'.user.id) <> (User_id.get_id m.user.id)) then
                     Some (Member_t.wrap ~guild_id m)
                 else None) in
             let guilds = Cache.GuildMap.set cache.guilds ~key:t.guild_id ~data:{ g with members } in
@@ -415,7 +416,7 @@ module GuildRoleDelete = struct
         if Cache.GuildMap.mem cache.guilds t.guild_id then
             let guilds = match Cache.GuildMap.find cache.guilds t.guild_id with
             | Some g ->
-                let roles = List.filter g.roles ~f:(fun r -> r.id <> t.role_id) in
+                let roles = List.filter g.roles ~f:(fun r -> (Role_id.get_id r.id) <> (Role_id.get_id t.role_id)) in
                 let data = { g with roles } in
                 Cache.GuildMap.set cache.guilds ~key:t.guild_id ~data
             | None -> cache.guilds in
@@ -437,7 +438,7 @@ module GuildRoleUpdate = struct
             | Some g ->
                 let `Guild_id guild_id = t.guild_id in
                 let roles = List.map g.roles ~f:(fun r ->
-                    if r.id = t.role.id then Role_t.wrap ~guild_id t.role else r) in
+                    if (Role_id.get_id r.id) = (Role_id.get_id t.role.id) then Role_t.wrap ~guild_id t.role else r) in
                 let data = { g with roles } in
                 Cache.GuildMap.set cache.guilds ~key:t.guild_id ~data
             | None -> cache.guilds in

--- a/lib/models/guild/guild.ml
+++ b/lib/models/guild/guild.ml
@@ -111,7 +111,7 @@ let unban_user ~id ?reason guild =
     in Http.guild_ban_remove (get_id guild) id payload
 
 let get_member ~(id:User_id_t.t) guild =
-    match List.find ~f:(fun m -> m.user.id = id) guild.members with
+    match List.find ~f:(fun m -> (User_id_t.get_id m.user.id) = (User_id_t.get_id id)) guild.members with
     | Some m -> Deferred.Or_error.return m
     | None ->
         let `User_id id = id in
@@ -125,4 +125,4 @@ let get_channel ~(id:Channel_id_t.t) guild =
 
 (* TODO add HTTP fallback *)
 let get_role ~(id:Role_id.t) guild =
-    List.find ~f:(fun r -> r.id = id) guild.roles
+    List.find ~f:(fun r -> (Role_id.get_id r.id) = (Role_id.get_id id)) guild.roles


### PR DESCRIPTION
Using decompress 1.4.2, the library as it exists right now does not compile. This PR slightly modifies the existing decompress function in `/lib/gateway/sharder.ml` and tweaks dune and opam files as necessary to make the lib compatible with the latest version of decompress. This PR also fixes some issues in models wherein `get_id` functions should've been used to extract integer IDs from `id_t`s but weren't.